### PR TITLE
Removes long disused parameter

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,3 @@ variable "roles" {
     type = list
 }
 
-variable "namespace" {
-    type = string
-}


### PR DESCRIPTION
TL;DR
-----

Gets rid of the `namespace` parameter

Details
-------

Drops the `namespace` parameter which hasn't been needed since the
caller became responsible for storing the key into a Kubernetes
secret if they wanted it there.